### PR TITLE
Add fr-fr locale

### DIFF
--- a/locale/fr-fr/bandcamp.voc
+++ b/locale/fr-fr/bandcamp.voc
@@ -1,0 +1,5 @@
+bandcamp
+sur bandcamp
+depuis bandcamp
+recherche sur bandcamp
+cherche sur bandcamp

--- a/locale/fr-fr/bandcamp_skill.voc
+++ b/locale/fr-fr/bandcamp_skill.voc
@@ -1,0 +1,2 @@
+bandcamp
+service bandcamp

--- a/locale/fr-fr/skill.json
+++ b/locale/fr-fr/skill.json
@@ -1,0 +1,8 @@
+{
+  "name": "Compétence Bandcamp",
+  "examples": [
+    "joue compressorhead",
+    "joue astronaut problems",
+    "joue ___ sur bandcamp"
+  ]
+}

--- a/translations/fr-fr/vocabs.json
+++ b/translations/fr-fr/vocabs.json
@@ -1,0 +1,13 @@
+{
+  "/bandcamp.voc": [
+    "bandcamp",
+    "sur bandcamp",
+    "depuis bandcamp",
+    "recherche sur bandcamp",
+    "cherche sur bandcamp"
+  ],
+  "/bandcamp_skill.voc": [
+    "bandcamp",
+    "service bandcamp"
+  ]
+}


### PR DESCRIPTION
## Summary
- add a complete `fr-fr` locale tree matching `en-us`
- add the matching `translations/fr-fr` snapshot files
- keep the French prompts natural for spoken assistant use